### PR TITLE
Sort ingredients in JSON Output

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -13,9 +13,9 @@ class Dish:
 
     def __repr__(self):
         if type(self.price) is not str:
-            return "%s %s: %.2f€" % (self.name, str(list(self.ingredients)), self.price)
+            return "%s %s: %.2f€" % (self.name, str(sorted(self.ingredients)), self.price)
         else:
-            return "%s %s: %s" % (self.name, str(list(self.ingredients)), self.price)
+            return "%s %s: %s" % (self.name, str(sorted(self.ingredients)), self.price)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -26,7 +26,7 @@ class Dish:
 
     def to_json_obj(self):
         return {"name": self.name, "price": self.price,
-             "ingredients": list(self.ingredients)}
+             "ingredients": sorted(self.ingredients)}
 
     def __hash__(self):
         # http://stackoverflow.com/questions/4005318/how-to-implement-a-good-hash-function-in-python


### PR DESCRIPTION
In the `gh-pages` history, we have lots of commits only changing the order of the ingredients over and over again (e.g. 8734d36).

In this PR, I sort the list of Ingredients in the JSON Output to prevent the changes to a new random order every time we run the parser.