### PR TITLE
Fix for Mixed Types in Prices

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -3,24 +3,21 @@
 import datetime
 import json
 import re
-from typing import Any, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 
 class Price:
-    base_price: Union[float, str]
+    base_price: Optional[float]
     price_per_unit: Optional[float]
     unit: Optional[str]
 
     def __init__(
         self,
-        base_price: Union[float, str],
+        base_price: Optional[float] = None,
         price_per_unit: Optional[float] = None,
         unit: Optional[str] = None,
     ):
-        try:
-            self.base_price = float(base_price)
-        except ValueError:
-            self.base_price = base_price
+        self.base_price = base_price
         self.price_per_unit = price_per_unit
         self.unit = unit
 
@@ -52,15 +49,12 @@ class Price:
 
 
 class Prices:
-    students: Price
-    staff: Price
-    guests: Price
+    students: Optional[Price]
+    staff: Optional[Price]
+    guests: Optional[Price]
 
     def __init__(self, students: Optional[Price] = None, staff: Optional[Price] = None, guests: Optional[Price] = None):
-        if students is None:
-            self.students = Price("N/A")
-        else:
-            self.students = students
+        self.students = students
         # fall back to the students price if there is only one price available
         if staff is None:
             self.staff = self.students
@@ -72,9 +66,12 @@ class Prices:
             self.guests = guests
 
     def setBasePrice(self, base_price: float) -> None:
-        self.students.base_price = base_price
-        self.staff.base_price = base_price
-        self.guests.base_price = base_price
+        if self.students is not None:
+            self.students.base_price = base_price
+        if self.staff is not None:
+            self.staff.base_price = base_price
+        if self.guests is not None:
+            self.guests.base_price = base_price
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
@@ -86,9 +83,9 @@ class Prices:
 
     def to_json_obj(self):
         return {
-            "students": self.students.to_json_obj(),
-            "staff": self.staff.to_json_obj(),
-            "guests": self.guests.to_json_obj(),
+            "students": self.students.to_json_obj() if self.students is not None else None,
+            "staff": self.staff.to_json_obj() if self.staff is not None else None,
+            "guests": self.guests.to_json_obj() if self.guests is not None else None,
         }
 
     def __hash__(self) -> int:

--- a/src/entities.py
+++ b/src/entities.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-import json
 import re
 from typing import Any, Dict, List, Optional, Sequence, Set
 
@@ -352,14 +351,6 @@ class Week:
                 for menu in self.days
             ],
         }
-
-    def to_json(self) -> str:
-        week_json: str = json.dumps(
-            self.to_json_obj(),
-            ensure_ascii=False,
-            indent=4,
-        )
-        return week_json
 
     @staticmethod
     # def to_weeks(menus: Dict[datetime.date, Menu]) -> Dict[int, Week]:

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,12 @@ import util
 from entities import Week
 from openmensa import openmensa
 
+"""
+The current version of the JSON output.
+Should be incremented as soon as the JSON output format changed in any way, shape or form.
+"""
+JSON_VERSION: str = "2.1"
+
 
 def get_menu_parsing_strategy(location):
     # set parsing strategy based on location
@@ -36,10 +42,12 @@ def jsonify(weeks, directory, location, combine_dishes):
             os.makedirs(f"{str(directory)}/{str(year)}")
 
         # convert Week object to JSON
-        week_json = week.to_json()
+        week_json = week.to_json_obj()
+        if week_json is not None:
+            week_json["version"] = JSON_VERSION
         # write JSON to file: <year>/<calendar_week>.json
         with open(f"{str(json_dir)}/{str(calendar_week).zfill(2)}.json", "w", encoding="utf-8") as outfile:
-            json.dump(json.loads(week_json), outfile, indent=4, ensure_ascii=False)
+            json.dump(week_json, outfile, indent=4, ensure_ascii=False)
 
     # check if combine parameter got set
     if not combine_dishes:
@@ -54,7 +62,11 @@ def jsonify(weeks, directory, location, combine_dishes):
 
     # convert all weeks to one JSON object
     weeks_json_all = json.dumps(
-        {"canteen_id": location, "weeks": [weeks[calendar_week].to_json_obj() for calendar_week in weeks]},
+        {
+            "version": JSON_VERSION,
+            "canteen_id": location,
+            "weeks": [weeks[calendar_week].to_json_obj() for calendar_week in weeks],
+        },
         ensure_ascii=False,
         indent=4,
     )


### PR DESCRIPTION
Fixes #23.
In case there is no price available, like shown here:
```JSON
"prices": {
    "students": {
        "base_price": "N/A",
        "price_per_unit": null,
        "unit": null
    },
    "staff": {
        "base_price": "N/A",
        "price_per_unit": null,
        "unit": null
    },
    "guests": {
        "base_price": "N/A",
        "price_per_unit": null,
        "unit": null
    }
}
```
We set the complete `Price` object to `null`.
```JSON
"prices": {
    "students": null,
    "staff": null,
    "guests": null,
}
```

Besides that, every generated JSON file now has a `version` attribute in its first level.
This version will be incremented each time the JSON format changes.
Example:
```JSON
{
    "number": 42,
    "year": 2021,
    "days": [],
    "version": 2.1
}
```