### PR TITLE
Resolves Issue #31

### DIFF
--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -243,9 +243,12 @@ class StudentenwerkMenuParser(MenuParser):
         # make duplicates unique by adding (2), (3) etc. to the names
         dish_names = util.make_duplicates_unique(dish_names)
         # obtain the types of the dishes (e.g. 'Tagesgericht 1')
-        dish_types: List[str] = [
-            type.text if type.text else "" for type in menu_html.xpath("//span[@class='stwm-artname']")
-        ]
+        dish_types: List[str] = []
+        current_type = ""
+        for type_ in menu_html.xpath("//span[@class='stwm-artname']"):
+            if type_.text:
+                current_type = type_.text
+            dish_types += [current_type]
         # obtain all ingredients
         dish_markers_additional: List[str] = menu_html.xpath(
             "//li[contains(@class, 'c-schedule__list-item  u-clearfix  clearfix  "


### PR DESCRIPTION
Fix: When associating a dish type to a dish, we now do the following:
- when the type is given in the same table row, we take this type (as it has been before)
- otherwise, we take the type of the previous line

For the probably not existent case that the first line does not have a type, we take an empty string.