### PR TITLE
Safari Fix

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -53,14 +53,14 @@ var ingredients = {
 };
 
 function dateFromString(raw) {
-    if (raw === undefined) {
-        var d = new Date();
+    const datePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+    if (raw === undefined || !raw.match(datePattern)) {
+        const d = new Date();
         // remove all time parameters, for easier comparing
         d.setHours(0, 0, 0, 0);
         return d;
     }
 
-    const datePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
     const [, year, month, day] = datePattern.exec(raw);
     return new Date(year, month - 1, day);
 }

--- a/js/app.js
+++ b/js/app.js
@@ -62,7 +62,7 @@ function dateFromString(raw) {
 
     const datePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
     const [, year, month, day] = datePattern.exec(raw);
-    return new Date(`${month}, ${day} ${year}`);
+    return new Date(year, month - 1, day);
 }
 
 function padNumber(n) {


### PR DESCRIPTION
This PR fixes an issue, where Safari browser were not able, to get the date from the URL.
Further, an other bug is fixed: When the date parameter in the URL doesn't represent a date, it now falls back to the current day. Before, the website didn't show anything anymore.