### PR TITLE
Website - UI Fixes - Location/Map

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,7 +13,11 @@ body {
 }
 
 #map {
-    height: 400px;
+    min-height: 70vh;
+}
+
+.map-modal{
+    min-width: 80vw;
 }
 
 img.active-marker {

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,10 +16,17 @@ body {
     min-height: 70vh;
 }
 
-.map-modal{
+.map-modal {
     min-width: 80vw;
 }
 
 img.active-marker {
     filter: hue-rotate(260deg); /* green color */
+}
+
+@media (prefers-color-scheme: dark) {
+    /* Increase contrast of modal closing button, in dark mode */
+    .delete::after, .delete::before, .modal-close::after, .modal-close::before {
+        background-color: black;
+    }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -221,6 +221,11 @@ function Controls() {
                 m.route.set(getHref({mensa}));
 
                 searchingForLocation = false;
+            }, function(e){
+                alert(`Geolocation could not be obtained: ${e.message}`);
+
+                searchingForLocation = false;
+                m.redraw(); // needed, as mithril has no auto update, for async state changes
             });
         } else {
             alert("Geolocation is not supported by this browser.");

--- a/js/app.js
+++ b/js/app.js
@@ -123,7 +123,8 @@ function Controls() {
     function openStreetMap() {
         return {
             oncreate: function (vnode) {
-                const map = L.map(vnode.dom)
+                // disable tap handler, to fix a bug when opening popups on iOS closes them immediately again (https://github.com/Leaflet/Leaflet/issues/7255)
+                const map = L.map(vnode.dom, {tap: false})
                     .setView([48.15, 11.55], 10); // coordinates for munich
                 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -221,7 +222,7 @@ function Controls() {
                 m.route.set(getHref({mensa}));
 
                 searchingForLocation = false;
-            }, function(e){
+            }, function (e) {
                 alert(`Geolocation could not be obtained: ${e.message}`);
 
                 searchingForLocation = false;

--- a/js/app.js
+++ b/js/app.js
@@ -189,7 +189,7 @@ function Controls() {
                                 showModal = false;
                             }
                         }),
-                        m("div", {class: "modal-content"},
+                        m("div", {class: "modal-content map-modal"},
                             m("div", {class: "card"},
                                 m("div", {class: "card-content"},
                                     m("div", {class: "content"},


### PR DESCRIPTION
This PR includes some UI fixes regarding the map on the website.

- Make the map in the modal larger, especially on large screens
- Stop loading animation for the location button, when permission is denied + show error message
- Increase contrast of the closing sign for the modals