### PR TITLE
Ingredient selection for website

### DIFF
--- a/js/components/labels.js
+++ b/js/components/labels.js
@@ -1,6 +1,58 @@
 import m from "../external/mithril.module.js";
+import {getHref, getFilterLabels} from "../modules/url-utils.js";
 
 let labels = [];
+
+function hideLabelCheckbox() {
+    function onchange(e) {
+        const {checked, value} = e.target;
+
+        // set new filters
+        let filter = [...getFilterLabels()];
+        if (checked) {
+            filter.push(value);
+        } else {
+            filter = filter.filter(v => v !== value);
+        }
+
+        // apply new url
+        const href = getHref({filter});
+        m.route.set(href);
+    }
+
+    return {
+        view: function (vnode) {
+            const filters = getFilterLabels();
+            const {value, disabled} = vnode.attrs;
+            const checked = filters && filters.indexOf(value) !== -1;
+            return m("input", {type: "checkbox", onchange, value, checked, disabled});
+        }
+    };
+}
+
+/**
+ * Returns the dishes to show and to hide for the given dishes in accordance with the filters set
+ *
+ * @param allDishes
+ * @returns {{hide: *, show: *}}
+ */
+export function getFilteredDishes(allDishes) {
+    /**
+     * Filter dish, if it includes one of the ingredients to be excluded
+     *
+     * @param dish
+     * @returns {boolean}
+     */
+    function filterDishes(dish) {
+        return !filter.some(f => dish.labels.indexOf(f) !== -1);
+    }
+
+    const filter = getFilterLabels();
+    // filter all dishes, which are hidden through the filters
+    const show = allDishes.filter(filterDishes);
+    const hide = allDishes.filter(dish => !filterDishes(dish));
+    return {show, hide};
+}
 
 function getLabelText(label) {
     const labelObject = labels.find(l => l["enum_name"] === label);
@@ -27,8 +79,9 @@ export function modal() {
         },
         view: function (vnode) {
             let {selectedLabels} = vnode.attrs;
+            const {readOnly} = vnode.attrs;
             if (!selectedLabels){
-                selectedLabels =  labels.map(l => l["enum_name"]);
+                selectedLabels = labels.map(l => l["enum_name"]);
             }
 
             let modalClass = "modal";
@@ -54,14 +107,15 @@ export function modal() {
                                 m("div", {class: "content"},
                                     m("table", {class: "table is-fullwidth"}, [
                                         m("thead",
-                                            m("tr", [m("th", "Symbol"), m("th", "Description")])),
+                                            m("tr", [m("th", "Symbol"), m("th", "Description"), m("th", "Hide")])),
                                         m("tbody", selectedLabels.map(function (label) {
                                             return m("tr", [
                                                 m("td", label),
-                                                m("td", getLabelText(label))
+                                                m("td", getLabelText(label)),
+                                                m("td", m(hideLabelCheckbox, {value: label, disabled: readOnly})),
                                             ]);
                                         })),
-                                        m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"})]))
+                                        m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"}), m("td", {class: "p-0"})]))
                                     ]))))),
                     m("button", {
                         class: "modal-close is-large", "aria-label": "close", onclick: function () {

--- a/js/modules/url-utils.js
+++ b/js/modules/url-utils.js
@@ -1,6 +1,6 @@
 import m from "../external/mithril.module.js";
 
-export function getHref({mensa, date}) {
+export function getHref({mensa, date, filter}) {
     if (mensa === undefined) {
         mensa = m.route.param("mensa");
     }
@@ -9,6 +9,30 @@ export function getHref({mensa, date}) {
         date = m.route.param("date");
     }
 
+    if (filter === undefined) {
+        filter = getFilterLabels();
+    }
+
     const parts = [mensa, date];
-    return `/${parts.filter(p => p).join("/")}`;
+
+    let query = "";
+    if (filter.length > 0) {
+        const params = m.buildQueryString({filter});
+        query = `?${params}`;
+    }
+
+    return `/${parts.filter(p => p).join("/")}${query}`;
+}
+
+/**
+ * Get the filters, which should be filtered currently
+ *
+ * @returns {string[]}
+ */
+export function getFilterLabels() {
+    const filters = m.route.param("filter");
+    if (filters === undefined) {
+        return [];
+    }
+    return filters;
 }


### PR DESCRIPTION
This PR includes a new functionality, to filter dishes based on their ingredients, as mentioned in https://github.com/TUM-Dev/eat-api/issues/27#issuecomment-977925292 so this should resolve #27.

It should be possible, to filter out dishes containing one of the given ingredients. Currently, this is possible via the modal, which opens up, when clicking on the info icon besides the _Dish_ headline.

![image](https://user-images.githubusercontent.com/1690395/145792009-5a6b6955-83e6-4a56-a670-1d909a8c2627.png)

The user interface is like this, when hiding dishes _with preservative_ and _with flavor enhancers_:
![image](https://user-images.githubusercontent.com/1690395/145792106-f09784b1-e1b3-468b-8a88-571de9372abd.png)
Additionally, the url is changed accordingly, the search path for the figure above is: `?filter%5B0%5D=2&filter%5B1%5D=4` (readable: `?filter[0]=2&filter[1]=4`)

I think the placement of the filters is not ideal, however I have not come up with a better idea yet.
Further, due to some internal mechanisms, I currently disabled the functionality, when the modal for a single dish is opened:
![image](https://user-images.githubusercontent.com/1690395/145792449-9c3a1c70-cec8-40db-a97d-9c4f2a9ad002.png)
Here I could also hide the column completely.

If you have better suggestions, on where to select the ingredients to hide, I'm happy to hear them.

Further, I want to add a button, to show the hidden dishes anyway, in case one would like to still check them out. E.g. there are some cases, where hiding things does not make that much sense, but I don't know any other way to handle it: 
![image](https://user-images.githubusercontent.com/1690395/145792744-a8d91196-e0fa-47b8-a2d7-6544c79d37cf.png)


I based this on modules, introduced by #72, to not have to rewrite it, once the modules are merged.