### PR TITLE
Website - Quick Bugfix: Make menus viewable again

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -362,9 +362,9 @@ function Day() {
                 return m("tr", [
                     m("td", [
                         m("p", dish.name),
-                        m(Ingredients, {ingredients: getDishIngredients(dish.ingredients)},
-                            m("span", {class: "is-size-7"}, dish.ingredients.map(function (ingredient) {
-                                return m("span", {class: "mx-1 is-inline-block", title: ingredients[ingredient].info}, ingredients[ingredient].symbol);
+                        m(Ingredients, {ingredients: getDishIngredients(dish.labels)},
+                            m("span", {class: "is-size-7"}, dish.labels.map(function (ingredient) {
+                                return m("span", {class: "mx-1 is-inline-block", title: ingredient}, ingredient);
                             }))
                         )
                     ]),
@@ -408,8 +408,8 @@ function Ingredients() {
                                             m("tr", [m("th", "Symbol"), m("th", "Description")])),
                                         m("tbody", Object.entries(ingredients).map(function (value) {
                                             return m("tr", [
-                                                m("td", value[1].symbol),
-                                                m("td", value[1].info)
+                                                m("td", value[1]),
+                                                m("td", value[1])
                                             ]);
                                         })),
                                         m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"})]))


### PR DESCRIPTION
This is a quick bug fix, to make menus viewable again on the eat-api website, as it is currently broken as mentioned in #79.

This makes it only possible to see the most recent menus.
I would propose to proceed, and load the correct labels enum json files together with the merge of the modules.
Otherwise I would have to do it almost twice, once without the modules and then once again with the modules.
Here another question: should I handle the new labels format as well as the old ingredients format? Or is it sufficient, that it won't break with the old ingredients, but also no further info? Or how would you handle this?

Additionally, I'm not sure how Git will handle this, because there is no a revert commit, and I already based other PRs on the modules?
Or do you think, we shouldn't introduce them? I just thought, that it would make things easer, as the `app.js` is now more than 500 LOC.
