### PR TITLE
Remove duplicate mentioning of canteens in parse script

### DIFF
--- a/scripts/parse.sh
+++ b/scripts/parse.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-CANTEEN_LIST=( "mensa-arcisstr" "mensa-garching" "mensa-leopoldstr" "mensa-lothstr" "mensa-martinsried" \
-"mensa-pasing" "mensa-weihenstephan" "stubistro-arcisstr" "stubistro-goethestr" "stubistro-grosshadern" \
-"stubistro-rosenheim" "stubistro-schellingstr" "stucafe-adalbertstr" "stucafe-akademie-weihenstephan" \
-"stucafe-boltzmannstr" "stucafe-garching" "stucafe-karlstr" "stucafe-pasing" "ipp-bistro" \
-"fmi-bistro" "mediziner-mensa" )
+CANTEEN_LIST=$(python3 src/main.py --canteens | python3 scripts/parse_canteen_list.py)
 OUT_DIR="${OUT_DIR:-dist}"
 LANGUAGE="${LANGUAGE_EAT_API:-DE}"
 
@@ -22,9 +18,9 @@ parse(){
 }
 
 # Parse all canteens:
-for canteen in "${CANTEEN_LIST[@]}";
+for canteen in ${CANTEEN_LIST};
 do
-( parse $canteen $LANGUAGE ) &
+ ( parse $canteen $LANGUAGE ) &
 done
 wait # Wait for all processes to finish
 

--- a/scripts/parse_canteen_list.py
+++ b/scripts/parse_canteen_list.py
@@ -1,0 +1,9 @@
+# script to show canteen_ids from json output line by line
+
+import json
+import sys
+
+if __name__ == "__main__":
+    canteens = json.load(sys.stdin)
+    for canteen in canteens:
+        print(canteen["canteen_id"])


### PR DESCRIPTION
Resolves #70

Instead of having a separate list of canteens in the `parse.sh` script, this allows to reuse the command from the `main.py`

I also thought about adding an option to parse all canteens at once, however, then we would loose the benefit of executing all script at the same time.