### PR TITLE
Update base_url to only include relative path

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -265,13 +265,13 @@ class Language(ApiRepresentable, Enum):
         self.label = label
         self.flag = flag
 
-    DE = "https://tum-dev.github.io/eat-api/", "Deutsch", "🇩🇪"
-    EN = "https://tum-dev.github.io/eat-api/en/", "English", "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
+    DE = "", "Deutsch", "🇩🇪"
+    EN = "en/", "English", "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
 
     def to_api_representation(self) -> Dict[str, object]:
         return {
             "name": self.name,
-            "base_url": self.base_url,
+            "base_url": self.base_url,  # relative to the root of the api
             "label": self.label,
             "flag": self.flag,
         }


### PR DESCRIPTION
As the API can have different deployment targets, I think it is more useful, to provide only a relative path for the base of each language.

This is especially useful, when developing the local website (with local API) so that no references to the public API are used.