### PR TITLE
Fix missing translations

### DIFF
--- a/scripts/parse.sh
+++ b/scripts/parse.sh
@@ -17,7 +17,7 @@ mkdir -p $OUT_DIR
 
 parse(){
     echo "Parsing menus for: $1 in $2..."
-    python3 src/main.py -p "$1" -j "./$OUT_DIR/$1" -c
+    python3 src/main.py -p "$1" -j "./$OUT_DIR/$1" -c --language $2
     echo "Parsing menus for: $1 done."
 }
 


### PR DESCRIPTION
This PR resolves #94 

Due to some refactoring in the parsing script, the language parameter got lost.
This resulted in german dish titles in the english API.

Here, the parameter is introduced again, and therefore future updates should be correct again.