### PR TITLE
[website] Fix URL for accessing menu data with different languages

### DIFF
--- a/js/components/menu.js
+++ b/js/components/menu.js
@@ -87,7 +87,6 @@ export default function Menu() {
             if (!languageObject) {
                 return;
             }
-            const language = languageObject["name"];
 
             const currentDate = dateFromString(m.route.param("date"));
             const {week, year} = getWeek(currentDate);
@@ -95,7 +94,6 @@ export default function Menu() {
                 mensa: m.route.param("mensa"),
                 year,
                 week: padNumber(week),
-                language
             };
 
             // if parameters have not changed, no new request is required
@@ -109,7 +107,7 @@ export default function Menu() {
 
             m.request({
                 method: "GET",
-                url: `${languageObject["base_url"]}/:mensa/:year/:week.json`,
+                url: `${languageObject["base_url"]}:mensa/:year/:week.json`,
                 params
             })
                 .then(function (menu) {


### PR DESCRIPTION
Resolves #102 

Don't add a "/" to the URL after the base path -> fixes german, as URL should be relative not absolute
Remove unneccessary language parameter from URL