### PR TITLE
[website] symbols and abbreviations for labels

### DIFF
--- a/js/components/labels.js
+++ b/js/components/labels.js
@@ -3,6 +3,7 @@ import translate, {getLanguage} from "../modules/translation.js";
 import {getHref, getFilterLabels} from "../modules/url-utils.js";
 
 let labels = [];
+let labelsLoadInitiated = false;
 
 function hideLabelCheckbox() {
     function onchange(e) {
@@ -72,7 +73,9 @@ export function modal() {
     return {
         oninit: function () {
             // avoid multiple loadings, as this should not change
-            if (labels.length === 0) {
+            if (!labelsLoadInitiated) {
+                labelsLoadInitiated = true;
+
                 m.request({
                     method: "GET",
                     url: "enums/labels.json"

--- a/js/components/labels.js
+++ b/js/components/labels.js
@@ -56,15 +56,27 @@ export function getFilteredDishes(allDishes) {
     return {show, hide};
 }
 
+function getLabelObject(label){
+    return labels.find(l => l["enum_name"] === label);
+}
+
 function getLabelText(label) {
     const language = getLanguage();
     const languageIdentifier = language["name"];
 
-    const labelObject = labels.find(l => l["enum_name"] === label);
+    const labelObject = getLabelObject(label);
     if (!labelObject) {
         return label;
     }
     return labelObject["text"][languageIdentifier];
+}
+
+function getLabelAbbreviation(label){
+    const labelObject = getLabelObject(label);
+    if (!labelObject || !labelObject["abbreviation"]) {
+        return label;
+    }
+    return labelObject["abbreviation"];
 }
 
 export function modal() {
@@ -117,7 +129,7 @@ export function modal() {
                                             m("tr", [m("th", translate("symbol")), m("th", translate("description")), m("th", translate("hide"))])),
                                         m("tbody", selectedLabels.map(function (label) {
                                             return m("tr", [
-                                                m("td", label),
+                                                m("td", getLabelAbbreviation(label)),
                                                 m("td", getLabelText(label)),
                                                 m("td", m(hideLabelCheckbox, {value: label, disabled: readOnly})),
                                             ]);
@@ -141,6 +153,6 @@ export function subline(labels) {
     }
 
     return labels.map(function (label) {
-        return m("span", {class: "mx-1 is-inline-block", title: getLabelText(label)}, label);
+        return m("span", {class: "mx-1 is-inline-block", title: getLabelText(label)}, getLabelAbbreviation(label));
     });
 }


### PR DESCRIPTION
This PR includes the symbols/abbreviations on the website again, as implemented through #85 
Additionally, I fixed a bug, where `labels.json` was loaded several times at the beginning.

<img width="713" alt="Bildschirmfoto 2022-01-06 um 19 24 55" src="https://user-images.githubusercontent.com/1690395/148432278-327c7937-aa3d-40e7-a673-2b6709784d84.png">


<img width="713" alt="Bildschirmfoto 2022-01-06 um 19 25 04" src="https://user-images.githubusercontent.com/1690395/148432205-bf93430b-7847-4db9-8ac1-a70243d380ea.png">



