### PR TITLE
[Website] Show opening hours

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -24,10 +24,22 @@ img.active-marker {
     filter: hue-rotate(260deg); /* green color */
 }
 
+/* move closing button for modal into model itself */
+.modal-close{
+    position: absolute;
+    z-index: 1;
+    right: 0;
+    top: 0;
+}
+
+/* Change color for closing button of modal, as background is now different */
+.modal-close::before, .modal-close::after{
+    background-color: black;
+}
+
 @media (prefers-color-scheme: dark) {
-    /* Increase contrast of modal closing button, in dark mode */
-    .delete::after, .delete::before, .modal-close::after, .modal-close::before {
-        background-color: black;
+    .modal-close::after, .modal-close::before {
+        background-color: white;
     }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,7 +16,7 @@ body {
     min-height: 70vh;
 }
 
-.map-modal {
+.map-modal .modal-content {
     min-width: 80vw;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -41,6 +41,11 @@ img.active-marker {
     .modal-close::after, .modal-close::before {
         background-color: white;
     }
+
+    /* make modal background color in dark mode not bright */
+    .modal-background {
+        background-color: rgba(54, 54, 54, 0.86);
+    }
 }
 
 .ws-5{

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import m from "./external/mithril.module.js";
 import DateSelection from "./components/date-selection.js";
 import LocationSelection from "./components/location-selection.js";
 import LanguageSelection from "./components/language-selection.js";
+import OpeningHours from "./components/opening-hours.js";
 
 import Menu from "./components/menu.js";
 import Translate from "./components/translate.js";
@@ -12,9 +13,12 @@ import {defaultLanguage} from "./modules/translation.js";
 function Controls() {
     return {
         view: function () {
-            return m("div", {class: "columns is-justify-content-space-between"}, [
-                m(LocationSelection),
-                m(DateSelection)
+            return m("div", [
+                m("div", {class: "columns is-justify-content-space-between"}, [
+                    m(LocationSelection),
+                    m(DateSelection)
+                ]),
+                m(OpeningHours)
             ]);
         }
     };

--- a/js/components/labels.js
+++ b/js/components/labels.js
@@ -1,6 +1,7 @@
 import m from "../external/mithril.module.js";
 import translate, {getLanguage} from "../modules/translation.js";
 import {getHref, getFilterLabels} from "../modules/url-utils.js";
+import Modal from "./modal.js";
 
 let labels = [];
 let labelsLoadInitiated = false;
@@ -56,7 +57,7 @@ export function getFilteredDishes(allDishes) {
     return {show, hide};
 }
 
-function getLabelObject(label){
+function getLabelObject(label) {
     return labels.find(l => l["enum_name"] === label);
 }
 
@@ -71,7 +72,7 @@ function getLabelText(label) {
     return labelObject["text"][languageIdentifier];
 }
 
-function getLabelAbbreviation(label){
+function getLabelAbbreviation(label) {
     const labelObject = getLabelObject(label);
     if (!labelObject || !labelObject["abbreviation"]) {
         return label;
@@ -80,8 +81,6 @@ function getLabelAbbreviation(label){
 }
 
 export function modal() {
-    let showModal = false;
-
     return {
         oninit: function () {
             // avoid multiple loadings, as this should not change
@@ -99,50 +98,24 @@ export function modal() {
         view: function (vnode) {
             let {selectedLabels} = vnode.attrs;
             const {readOnly} = vnode.attrs;
-            if (!selectedLabels){
+            if (!selectedLabels) {
                 selectedLabels = labels.map(l => l["enum_name"]);
             }
 
-            let modalClass = "modal";
-            if (showModal) {
-                modalClass += " is-active";
-            }
-
-            return m("span", [
-                m("span", {
-                    class: "is-clickable", onclick: function () {
-                        showModal = true;
-                    }
-                }, vnode.children),
-                m("div", {class: modalClass}, [
-                    m("div", {
-                        class: "modal-background", onclick: function () {
-                            showModal = false;
-                        }
-                    }),
-                    m("div", {class: "modal-content"},
-                        m("div", {class: "card"},
-                            m("div", {class: "card-content"},
-                                m("div", {class: "content"},
-                                    m("table", {class: "table is-fullwidth"}, [
-                                        m("thead",
-                                            m("tr", [m("th", translate("symbol")), m("th", translate("description")), m("th", translate("hide"))])),
-                                        m("tbody", selectedLabels.map(function (label) {
-                                            return m("tr", [
-                                                m("td", getLabelAbbreviation(label)),
-                                                m("td", getLabelText(label)),
-                                                m("td", m(hideLabelCheckbox, {value: label, disabled: readOnly})),
-                                            ]);
-                                        })),
-                                        m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"}), m("td", {class: "p-0"})]))
-                                    ]))))),
-                    m("button", {
-                        class: "modal-close is-large", "aria-label": "close", onclick: function () {
-                            showModal = false;
-                        }
-                    })
-                ])
+            const content = m("table", {class: "table is-fullwidth"}, [
+                m("thead",
+                    m("tr", [m("th", translate("symbol")), m("th", translate("description")), m("th", translate("hide"))])),
+                m("tbody", selectedLabels.map(function (label) {
+                    return m("tr", [
+                        m("td", getLabelAbbreviation(label)),
+                        m("td", getLabelText(label)),
+                        m("td", m(hideLabelCheckbox, {value: label, disabled: readOnly})),
+                    ]);
+                })),
+                m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"}), m("td", {class: "p-0"})]))
             ]);
+
+            return m(Modal, {content}, vnode.children);
         }
     };
 }

--- a/js/components/location-selection.js
+++ b/js/components/location-selection.js
@@ -2,8 +2,8 @@ import L from "../external/leaflet.module.js";
 import m from "../external/mithril.module.js";
 import {getHref} from "../modules/url-utils.js";
 import translate from "../modules/translation.js";
+import Modal from "./modal.js";
 
-let showModal = false;
 export let canteens = [];
 
 function openStreetMap() {
@@ -56,38 +56,6 @@ function openStreetMap() {
         },
         view: function () {
             return m("div", {id: "map"});
-        }
-    };
-}
-
-function mapModal() {
-    return {
-        view: function () {
-            return [
-                m("span", {
-                    class: "button", onclick: function () {
-                        showModal = true;
-                    }
-                }, [m("span", {class: "icon"}, m("i", {class: "fa fa-map"}))
-                ]),
-                m("div", {class: `modal ${showModal ? "is-active" : ""}`}, [
-                    m("div", {
-                        class: "modal-background", onclick: function () {
-                            showModal = false;
-                        }
-                    }),
-                    m("div", {class: "modal-content map-modal"},
-                        m("div", {class: "card"},
-                            m("div", {class: "card-content"},
-                                m("div", {class: "content"},
-                                    m(openStreetMap))))),
-                    m("button", {
-                        class: "modal-close is-large", "aria-label": "close", onclick: function () {
-                            showModal = false;
-                        }
-                    })
-                ])
-            ];
         }
     };
 }
@@ -153,8 +121,8 @@ export default function LocatioSelection() {
                         m("span", {class: "icon"}, m("i", {class: `fa ${searchingForLocation ? "fa-spinner fa-spin" : "fa-location-arrow"}`}))
                     ])
                 ),
-                m("p", {class: "control"},
-                    m(mapModal)
+                m("p", {class: "control map-modal"},
+                    m(Modal, {content: m(openStreetMap)}, m("span", {class: "button"}, m("span", {class: "icon"}, m("i", {class: "fa fa-map"})))),
                 ),
             ]);
         }

--- a/js/components/location-selection.js
+++ b/js/components/location-selection.js
@@ -4,7 +4,7 @@ import {getHref} from "../modules/url-utils.js";
 import translate from "../modules/translation.js";
 
 let showModal = false;
-let canteens = [];
+export let canteens = [];
 
 function openStreetMap() {
     return {

--- a/js/components/modal.js
+++ b/js/components/modal.js
@@ -1,0 +1,28 @@
+import m from "../external/mithril.module.js";
+
+export default function Modal() {
+    let showModal = false;
+
+    return {
+        view: function (vnode) {
+            let modalClass = "modal";
+            if (showModal) {
+                modalClass += " is-active";
+            }
+
+            return m("span", [
+                m("span", {class: "is-clickable", onclick: () => showModal = true}, vnode.children),
+                m("div", {class: modalClass}, [
+                    m("div", {class: "modal-background", onclick: () => showModal = false}),
+                    m("div", {class: "modal-content"},
+                        m("div", {class: "card"},
+                            m("div", {class: "card-content"},
+                                m("div", {class: "content"},
+                                    vnode.attrs.content
+                                )))),
+                    m("button", {class: "modal-close is-large", "aria-label": "close", onclick: () => showModal = false})
+                ])
+            ]);
+        }
+    };
+}

--- a/js/components/modal.js
+++ b/js/components/modal.js
@@ -14,13 +14,14 @@ export default function Modal() {
                 m("span", {class: "is-clickable", onclick: () => showModal = true}, vnode.children),
                 m("div", {class: modalClass}, [
                     m("div", {class: "modal-background", onclick: () => showModal = false}),
-                    m("div", {class: "modal-content"},
+                    m("div", {class: "modal-content"}, [
+                        m("button", {class: "modal-close is-large", "aria-label": "close", onclick: () => showModal = false}),
                         m("div", {class: "card"},
                             m("div", {class: "card-content"},
                                 m("div", {class: "content"},
                                     vnode.attrs.content
-                                )))),
-                    m("button", {class: "modal-close is-large", "aria-label": "close", onclick: () => showModal = false})
+                                )))
+                    ]),
                 ])
             ]);
         }

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -63,6 +63,8 @@ function modal() {
                 modalClass += " is-active";
             }
 
+            const {canteen} = vnode.attrs;
+
             return m("span", [
                 m("span", {class: "is-clickable", onclick: () => showModal = true}, vnode.children),
                 m("div", {class: modalClass}, [
@@ -72,7 +74,7 @@ function modal() {
                             m("div", {class: "card-content"},
                                 m("div", {class: "content"},
                                     [
-                                        m("h3", translate("opening-hours")),
+                                        m("h3", translate("opening-hours", {canteen})),
                                         m("table", [
                                             m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
                                             m("tbody", Object.entries(vnode.attrs.openingHours).map(v =>
@@ -91,7 +93,8 @@ function modal() {
 export default function OpeningHours() {
     return {
         view: function () {
-            const openingHours = getOpeningHours(m.route.param("mensa"));
+            const canteen = m.route.param("mensa");
+            const openingHours = getOpeningHours(canteen);
             const selectedDate = dateFromString(m.route.param("date"));
             const openingHoursDate = getOpeningHoursForDate(openingHours, selectedDate);
 
@@ -111,7 +114,7 @@ export default function OpeningHours() {
 
             return m("div", {class: "has-text-centered"},
                 m("span", {class: textColor}, translate("opened", openingHoursDate)),
-                m(modal, {openingHours}, m("i", {class: "fa fa-info-circle ml-1"}))
+                m(modal, {openingHours, canteen}, m("i", {class: "fa fa-info-circle ml-1"}))
             );
         }
     };

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -2,7 +2,7 @@ import m from "../external/mithril.module.js";
 import translate from "../modules/translation.js";
 
 import {canteens} from "./location-selection.js";
-import { dateFromString, getDateWithTime} from "../modules/date-utils.js";
+import {dateFromString, getDateWithTime} from "../modules/date-utils.js";
 
 
 function getOpeningHours(canteenId) {
@@ -53,6 +53,41 @@ function getStatus(openingHoursDate, selectedDate) {
     return 2;
 }
 
+function modal() {
+    let showModal = false;
+
+    return {
+        view: function (vnode) {
+            let modalClass = "modal";
+            if (showModal) {
+                modalClass += " is-active";
+            }
+
+            return m("span", [
+                m("span", {class: "is-clickable", onclick: () => showModal = true}, vnode.children),
+                m("div", {class: modalClass}, [
+                    m("div", {class: "modal-background", onclick: () => showModal = false}),
+                    m("div", {class: "modal-content"},
+                        m("div", {class: "card"},
+                            m("div", {class: "card-content"},
+                                m("div", {class: "content"},
+                                    [
+                                        m("h3", translate("opening-hours")),
+                                        m("table", [
+                                            m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
+                                            m("tbody", Object.entries(vnode.attrs.openingHours).map(v =>
+                                                m("tr", [m("td", translate(v[0])), m("td", v[1].start), m("td", v[1].end)])
+                                            ))
+                                        ])
+                                    ]
+                                )))),
+                    m("button", {class: "modal-close is-large", "aria-label": "close", onclick: () => showModal = false})
+                ])
+            ]);
+        }
+    };
+}
+
 export default function OpeningHours() {
     return {
         view: function () {
@@ -75,7 +110,8 @@ export default function OpeningHours() {
             const textColor = statusToClassMapping[status];
 
             return m("div", {class: "has-text-centered"},
-                m("span", {class: textColor}, translate("opened", openingHoursDate))
+                m("span", {class: textColor}, translate("opened", openingHoursDate)),
+                m(modal, {openingHours}, m("i", {class: "fa fa-info-circle ml-1"}))
             );
         }
     };

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -1,6 +1,7 @@
 import m from "../external/mithril.module.js";
 import translate from "../modules/translation.js";
 
+import Modal from "./modal.js";
 import {canteens} from "./location-selection.js";
 import {dateFromString, getDateWithTime} from "../modules/date-utils.js";
 
@@ -53,43 +54,6 @@ function getStatus(openingHoursDate, selectedDate) {
     return 2;
 }
 
-function modal() {
-    let showModal = false;
-
-    return {
-        view: function (vnode) {
-            let modalClass = "modal";
-            if (showModal) {
-                modalClass += " is-active";
-            }
-
-            const {canteen} = vnode.attrs;
-
-            return m("span", [
-                m("span", {class: "is-clickable", onclick: () => showModal = true}, vnode.children),
-                m("div", {class: modalClass}, [
-                    m("div", {class: "modal-background", onclick: () => showModal = false}),
-                    m("div", {class: "modal-content"},
-                        m("div", {class: "card"},
-                            m("div", {class: "card-content"},
-                                m("div", {class: "content"},
-                                    [
-                                        m("h3", translate("opening-hours", {canteen})),
-                                        m("table", [
-                                            m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
-                                            m("tbody", Object.entries(vnode.attrs.openingHours).map(v =>
-                                                m("tr", [m("td", translate(v[0])), m("td", v[1].start), m("td", v[1].end)])
-                                            ))
-                                        ])
-                                    ]
-                                )))),
-                    m("button", {class: "modal-close is-large", "aria-label": "close", onclick: () => showModal = false})
-                ])
-            ]);
-        }
-    };
-}
-
 export default function OpeningHours() {
     return {
         view: function () {
@@ -112,9 +76,19 @@ export default function OpeningHours() {
             };
             const textColor = statusToClassMapping[status];
 
+            const modalContent = [
+                m("h3", translate("opening-hours", {canteen})),
+                m("table", [
+                    m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
+                    m("tbody", Object.entries(openingHours).map(v =>
+                        m("tr", [m("td", translate(v[0])), m("td", v[1].start), m("td", v[1].end)])
+                    ))
+                ])
+            ];
+
             return m("div", {class: "has-text-centered"},
                 m("span", {class: textColor}, translate("opened", openingHoursDate)),
-                m(modal, {openingHours, canteen}, m("i", {class: "fa fa-info-circle ml-1"}))
+                m(Modal, {content: modalContent}, m("i", {class: "fa fa-info-circle ml-1"}))
             );
         }
     };

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -76,18 +76,25 @@ export default function OpeningHours() {
             };
             const textColor = statusToClassMapping[status];
 
-            const modalContent = [
+            const modalContent = m("div", {class: "has-text-left"}, [
                 m("h3", translate("opening-hours", {canteen})),
                 m("table", [
                     m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
                     m("tbody", Object.entries(openingHours).map(v =>
                         m("tr", [m("td", translate(v[0])), m("td", v[1].start), m("td", v[1].end)])
                     ))
-                ])
-            ];
+                ]),
+                m("p", {class: "mt-6"}, [
+                    m("h5", translate("text-color")),
+                    m("p", {class: statusToClassMapping[0]}, translate("opening-hours-0")),
+                    m("p", {class: statusToClassMapping[1]}, translate("opening-hours-1")),
+                    m("p", {class: statusToClassMapping[2]}, translate("opening-hours-2")),
+                    m("p", {class: statusToClassMapping[3]}, translate("opening-hours-3")),
+                ]),
+            ]);
 
             return m("div", {class: "has-text-centered"},
-                m("span", {class: textColor}, translate("opened", openingHoursDate)),
+                m("span", {class: textColor, title: translate(`opening-hours-${status}`)}, translate("opened", openingHoursDate)),
                 m(Modal, {content: modalContent}, m("i", {class: "fa fa-info-circle ml-1"}))
             );
         }

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -1,0 +1,82 @@
+import m from "../external/mithril.module.js";
+import translate from "../modules/translation.js";
+
+import {canteens} from "./location-selection.js";
+import { dateFromString, getDateWithTime} from "../modules/date-utils.js";
+
+
+function getOpeningHours(canteenId) {
+    const canteen = canteens.find(v => v.canteen_id === canteenId);
+    if (!canteen) {
+        return false;
+    }
+
+    return canteen["open_hours"];
+}
+
+function getOpeningHoursForDate(openHours, date) {
+    // mapping from js date weekdays to API weekdays
+    const mapping = {
+        0: "sun",
+        1: "mon",
+        2: "tue",
+        3: "wed",
+        4: "thu",
+        5: "fri",
+        6: "sat"
+    };
+
+    const weekDay = date.getDay();
+    const apiWeekDay = mapping[weekDay];
+
+    return openHours[apiWeekDay];
+}
+
+// 0 = not today, 1 = will open, 2 = open, 3 = was open
+function getStatus(openingHoursDate, selectedDate) {
+    // check if selectedDate is today
+    const now = new Date();
+
+    if (selectedDate.getDate() !== now.getDate() || selectedDate.getMonth() !== now.getMonth() || selectedDate.getFullYear() !== now.getFullYear()) {
+        return 0;
+    }
+
+    const start = getDateWithTime(selectedDate, openingHoursDate["start"]);
+    if (now < start) {
+        return 1;
+    }
+
+    const end = getDateWithTime(selectedDate, openingHoursDate["end"]);
+    if (now > end) {
+        return 3;
+    }
+    return 2;
+}
+
+export default function OpeningHours() {
+    return {
+        view: function () {
+            const openingHours = getOpeningHours(m.route.param("mensa"));
+            const selectedDate = dateFromString(m.route.param("date"));
+            const openingHoursDate = getOpeningHoursForDate(openingHours, selectedDate);
+
+            // if no open hours found, don't show any text
+            if (!openingHoursDate) {
+                return m("div");
+            }
+
+            const status = getStatus(openingHoursDate, selectedDate);
+            const statusToClassMapping = {
+                0: "",
+                1: "has-text-info",
+                2: "has-text-success",
+                3: "has-text-danger",
+            };
+            const textColor = statusToClassMapping[status];
+
+            return m("div", {class: "has-text-centered"},
+                m("span", {class: textColor}, translate("opened", openingHoursDate))
+            );
+        }
+    };
+}

--- a/js/components/opening-hours.js
+++ b/js/components/opening-hours.js
@@ -82,7 +82,8 @@ export default function OpeningHours() {
                     m("thead", [m("th", translate("weekday")), m("th", translate("opens")), m("th", translate("closes"))]),
                     m("tbody", Object.entries(openingHours).map(v =>
                         m("tr", [m("td", translate(v[0])), m("td", v[1].start), m("td", v[1].end)])
-                    ))
+                    )),
+                    m("tfoot", m("tr", [m("td", {class: "p-0"}), m("td", {class: "p-0"}), m("td", {class: "p-0"})]))
                 ]),
                 m("p", {class: "mt-6"}, [
                     m("h5", translate("text-color")),
@@ -93,7 +94,7 @@ export default function OpeningHours() {
                 ]),
             ]);
 
-            return m("div", {class: "has-text-centered"},
+            return m("div", {class: "has-text-centered mb-3"},
                 m("span", {class: textColor, title: translate(`opening-hours-${status}`)}, translate("opened", openingHoursDate)),
                 m(Modal, {content: modalContent}, m("i", {class: "fa fa-info-circle ml-1"}))
             );

--- a/js/modules/date-utils.js
+++ b/js/modules/date-utils.js
@@ -48,3 +48,20 @@ export function getWeek(day) {
 export function copyDate(date) {
     return new Date(date.getTime());
 }
+
+/**
+ * Create a new date with the time given on the same date as the given date
+ *
+ * @param {Date} date
+ * @param {string} time Format has to be \d\d:\d\d
+ */
+export function getDateWithTime(date, time){
+    const out = copyDate(date);
+
+    const result = time.match(/(\d\d):(\d\d)/);
+    const hours = parseInt(result[1]);
+    const minutes = parseInt(result[2]);
+
+    out.setHours(hours, minutes);
+    return out;
+}

--- a/js/modules/translation.js
+++ b/js/modules/translation.js
@@ -58,6 +58,11 @@ const resources = {
             "opens": "Opens",
             "closes": "Closes",
             "opening-hours": "Opening hours {{canteen}}",
+            "text-color": "Text color",
+            "opening-hours-0": "Black: The selected date is not today",
+            "opening-hours-1": "Blue: canteen will open later today",
+            "opening-hours-2": "Green: canteen is currently open",
+            "opening-hours-3": "Red: canteen is already closed",
         }
     },
     de: {
@@ -85,6 +90,11 @@ const resources = {
             "opens": "Öffnet",
             "closes": "Schließt",
             "opening-hours": "Öffnungszeiten {{canteen}}",
+            "text-color": "Farbe der Öffnungszeitenanzeige",
+            "opening-hours-0": "Schwarz: Das ausgewählte Datum ist nicht heute",
+            "opening-hours-1": "Blau: Die Mensa wird später öffnen",
+            "opening-hours-2": "Grün: Die Mensa ist aktuell geöffnet",
+            "opening-hours-3": "Rot: Die Mensa hat bereits geschlossen",
         }
     }
 };

--- a/js/modules/translation.js
+++ b/js/modules/translation.js
@@ -48,6 +48,7 @@ const resources = {
             "no-menu-for-date": "There is no menu for {{date}}",
             "location-invalid": "A location with the id {{location}} does not exist.",
             "closest-canteen": "Select closest canteen",
+            "opened": "Opened from {{start}} to {{end}}",
         }
     },
     de: {
@@ -65,6 +66,7 @@ const resources = {
             "no-menu-for-date": "Es gibt kein Menü für {{date}}",
             "location-invalid": "Es gibt keine Mensa mit der ID {{location}}",
             "closest-canteen": "Nächstgelegene Mensa auswählen",
+            "opened": "Geöffnet von {{start}} bis {{end}}",
         }
     }
 };

--- a/js/modules/translation.js
+++ b/js/modules/translation.js
@@ -49,6 +49,15 @@ const resources = {
             "location-invalid": "A location with the id {{location}} does not exist.",
             "closest-canteen": "Select closest canteen",
             "opened": "Opened from {{start}} to {{end}}",
+            "mon": "Monday",
+            "tue": "Tuesday",
+            "wed": "Wednesday",
+            "thu": "Thursday",
+            "fri": "Friday",
+            "weekday": "Weekday",
+            "opens": "Opens",
+            "closes": "Closes",
+            "opening-hours": "Opening hours",
         }
     },
     de: {
@@ -67,6 +76,15 @@ const resources = {
             "location-invalid": "Es gibt keine Mensa mit der ID {{location}}",
             "closest-canteen": "Nächstgelegene Mensa auswählen",
             "opened": "Geöffnet von {{start}} bis {{end}}",
+            "mon": "Montag",
+            "tue": "Dienstag",
+            "wed": "Mittwoch",
+            "thu": "Donnerstag",
+            "fri": "Freitag",
+            "weekday": "Wochentag",
+            "opens": "Öffnet",
+            "closes": "Schließt",
+            "opening-hours": "Öffnungszeiten",
         }
     }
 };

--- a/js/modules/translation.js
+++ b/js/modules/translation.js
@@ -57,7 +57,7 @@ const resources = {
             "weekday": "Weekday",
             "opens": "Opens",
             "closes": "Closes",
-            "opening-hours": "Opening hours",
+            "opening-hours": "Opening hours {{canteen}}",
         }
     },
     de: {
@@ -84,7 +84,7 @@ const resources = {
             "weekday": "Wochentag",
             "opens": "Öffnet",
             "closes": "Schließt",
-            "opening-hours": "Öffnungszeiten",
+            "opening-hours": "Öffnungszeiten {{canteen}}",
         }
     }
 };


### PR DESCRIPTION
Resolves #114 

Ready for merge after #105 

Displays the opening hours for a canteen on the gh-pages website.
This looks currently as follows:
![Bildschirmfoto 2022-01-25 um 19 59 44](https://user-images.githubusercontent.com/1690395/151042949-61d14f84-f859-46f6-b96e-7430aa7b4149.png)

The text can have different colors:
- red, when the canteen already closed
- green, when the canteen is open
- blue, when the canteen will open today
- black, when the selected day is not today

Further, a click on the info icon will open a modal, that shows all opening hours for the given canteen:
![Bildschirmfoto 2022-01-25 um 19 59 51](https://user-images.githubusercontent.com/1690395/151043217-96c14e70-ff3b-49f9-aa35-d0c9fbc3c60e.png)