### PR TITLE
Fix: change dish title immediately, when changing the language

### DIFF
--- a/js/components/menu.js
+++ b/js/components/menu.js
@@ -94,6 +94,7 @@ export default function Menu() {
                 mensa: m.route.param("mensa"),
                 year,
                 week: padNumber(week),
+                language: languageObject["name"],
             };
 
             // if parameters have not changed, no new request is required
@@ -103,7 +104,10 @@ export default function Menu() {
             if (!isDifferent) {
                 return;
             }
-            MenuData.currentParams = params;
+
+            // include language only for the check, whether parameters have changed
+            MenuData.currentParams = {...params};
+            delete params.language; // delete language, before it is used for the request
 
             m.request({
                 method: "GET",


### PR DESCRIPTION
Currently, there is a small bug, when changing the language, the menu gets only updated after a reload of the menu.
This PR fixes this issue.

Before (with page reload): 
![before](https://user-images.githubusercontent.com/1690395/151206038-4dc55e0a-f034-463c-8bef-f06c4acf0c19.gif)


Now: 
![now](https://user-images.githubusercontent.com/1690395/151206057-74192b63-07af-459a-962b-90d02ea9775b.gif)

