### PR TITLE
Fix url for mensa garching queue status API

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -188,7 +188,7 @@ components:
           description:
             URL to another API, where data about the queue length of the canteen
             can be accessed. Is null, when not available.
-          example: https://mensa.liste.party/api
+          example: https://mensa.liste.party/api/
         open_hours:
           $ref: '#/components/schemas/OpenHoursWeek'
     OpenHoursWeek:

--- a/src/entities.py
+++ b/src/entities.py
@@ -169,7 +169,7 @@ class Canteen(ApiRepresentable, Enum):
         "Mensa Garching",
         Location("Boltzmannstraße 19, Garching", 48.268132, 11.672263),
         422,
-        "https://mensa.liste.party/api",
+        "https://mensa.liste.party/api/",
         OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
     )
     MENSA_LEOPOLDSTR = (


### PR DESCRIPTION
Resolve an issue regarding PR #117  

Previous URL pointed to a 301 redirect, to the new URL

This could be a problem, as there is no CORS present for the 301 redirect, and therefore a browser can't follow to the new URL.