### PR TITLE
Adapt Tests to Price Changes

### DIFF
--- a/src/test/assets/studentenwerk/mensa-arcisstr/reference/combined.json
+++ b/src/test/assets/studentenwerk/mensa-arcisstr/reference/combined.json
@@ -14,17 +14,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -46,17 +46,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -77,17 +77,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -117,12 +117,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -148,12 +148,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -167,17 +167,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -195,17 +195,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -230,17 +230,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -257,17 +257,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -283,17 +283,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -309,17 +309,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -335,17 +335,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -379,17 +379,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -411,17 +411,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -441,17 +441,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -473,17 +473,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -506,17 +506,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -541,12 +541,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -562,17 +562,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -589,17 +589,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -625,17 +625,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -650,17 +650,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -685,17 +685,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -713,17 +713,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -738,17 +738,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -764,17 +764,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -795,17 +795,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -826,17 +826,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -852,17 +852,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -880,17 +880,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -905,17 +905,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -947,17 +947,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -979,17 +979,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1005,17 +1005,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1049,17 +1049,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1079,17 +1079,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1110,17 +1110,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1146,17 +1146,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1187,12 +1187,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1216,12 +1216,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1235,17 +1235,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1268,17 +1268,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1302,17 +1302,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1328,17 +1328,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1359,17 +1359,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1383,17 +1383,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1408,17 +1408,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1447,17 +1447,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1480,17 +1480,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1508,17 +1508,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1542,17 +1542,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1581,17 +1581,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1618,12 +1618,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1646,12 +1646,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1665,17 +1665,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1691,17 +1691,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1722,17 +1722,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1754,17 +1754,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1782,17 +1782,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1812,17 +1812,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1843,17 +1843,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1871,17 +1871,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1903,17 +1903,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1936,17 +1936,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1972,17 +1972,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2008,17 +2008,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2039,17 +2039,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2075,12 +2075,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2102,12 +2102,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2121,17 +2121,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2155,17 +2155,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2189,17 +2189,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2214,17 +2214,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2239,17 +2239,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2269,17 +2269,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2294,17 +2294,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2332,17 +2332,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2365,17 +2365,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2389,17 +2389,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2417,17 +2417,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2452,12 +2452,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2477,12 +2477,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2496,17 +2496,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2527,17 +2527,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2554,17 +2554,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2580,17 +2580,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2605,17 +2605,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2631,17 +2631,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2660,17 +2660,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2690,17 +2690,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2714,17 +2714,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2754,12 +2754,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2782,12 +2782,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2801,17 +2801,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2834,17 +2834,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2863,17 +2863,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2893,17 +2893,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2924,17 +2924,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2948,17 +2948,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2979,12 +2979,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3000,17 +3000,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3029,17 +3029,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3062,17 +3062,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3090,17 +3090,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3118,17 +3118,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3147,17 +3147,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3177,17 +3177,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3208,17 +3208,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3232,17 +3232,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3265,12 +3265,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3295,12 +3295,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3314,17 +3314,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3338,17 +3338,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3367,17 +3367,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3391,17 +3391,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3422,17 +3422,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3454,17 +3454,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3478,17 +3478,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3512,12 +3512,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3541,12 +3541,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3560,17 +3560,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3594,17 +3594,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3625,17 +3625,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3651,17 +3651,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },

--- a/src/test/assets/studentenwerk/mensa-garching/reference/combined.json
+++ b/src/test/assets/studentenwerk/mensa-garching/reference/combined.json
@@ -14,17 +14,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -46,17 +46,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -84,12 +84,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -115,12 +115,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -137,17 +137,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -166,17 +166,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -201,17 +201,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -228,17 +228,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -253,17 +253,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -279,17 +279,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -308,17 +308,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -334,17 +334,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -376,17 +376,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -408,17 +408,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -441,17 +441,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -467,17 +467,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -506,17 +506,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -531,17 +531,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -561,17 +561,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -593,17 +593,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -627,17 +627,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -663,12 +663,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -692,12 +692,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -717,17 +717,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -745,17 +745,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -783,17 +783,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -812,17 +812,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -837,17 +837,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -865,17 +865,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -890,17 +890,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -932,17 +932,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -964,17 +964,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -997,17 +997,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1023,17 +1023,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1048,17 +1048,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1078,17 +1078,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1108,17 +1108,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1152,12 +1152,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1180,12 +1180,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1204,17 +1204,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1237,17 +1237,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1271,17 +1271,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1301,17 +1301,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1327,17 +1327,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1351,17 +1351,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1376,17 +1376,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1402,17 +1402,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1444,17 +1444,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1478,17 +1478,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1504,17 +1504,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1534,17 +1534,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1564,17 +1564,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1589,17 +1589,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1619,17 +1619,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1652,17 +1652,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1686,17 +1686,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1725,17 +1725,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1762,12 +1762,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1790,12 +1790,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1814,17 +1814,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1840,17 +1840,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1873,17 +1873,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1910,17 +1910,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1942,17 +1942,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1980,17 +1980,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2007,17 +2007,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2033,17 +2033,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2058,17 +2058,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2087,17 +2087,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2115,17 +2115,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2141,17 +2141,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2169,17 +2169,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2211,17 +2211,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2243,17 +2243,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2273,17 +2273,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2312,17 +2312,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2337,17 +2337,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2367,17 +2367,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2399,17 +2399,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2430,17 +2430,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2468,12 +2468,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2496,12 +2496,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2529,12 +2529,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2552,17 +2552,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2578,17 +2578,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2613,17 +2613,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2643,17 +2643,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2668,17 +2668,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2693,17 +2693,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2723,17 +2723,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2748,17 +2748,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2790,17 +2790,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2822,17 +2822,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2853,17 +2853,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2883,17 +2883,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2908,17 +2908,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2944,17 +2944,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2977,17 +2977,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3005,17 +3005,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3040,12 +3040,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3065,12 +3065,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3087,17 +3087,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3118,17 +3118,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3145,17 +3145,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3171,17 +3171,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3199,17 +3199,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3225,17 +3225,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3250,17 +3250,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3274,17 +3274,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3316,17 +3316,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3348,17 +3348,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3375,17 +3375,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3407,17 +3407,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3432,17 +3432,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3464,17 +3464,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3494,17 +3494,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3525,17 +3525,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3565,12 +3565,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3593,12 +3593,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3612,17 +3612,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3645,17 +3645,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3674,17 +3674,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3701,17 +3701,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3726,17 +3726,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3752,17 +3752,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3777,17 +3777,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3803,17 +3803,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3845,17 +3845,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3877,17 +3877,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3904,17 +3904,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3929,17 +3929,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3959,17 +3959,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3990,17 +3990,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4021,12 +4021,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4048,12 +4048,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4067,17 +4067,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4096,17 +4096,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4129,17 +4129,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4155,17 +4155,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4183,17 +4183,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4209,17 +4209,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4238,17 +4238,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4263,17 +4263,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4305,17 +4305,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4337,17 +4337,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4363,17 +4363,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4388,17 +4388,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4418,17 +4418,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4449,17 +4449,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4484,17 +4484,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4517,12 +4517,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4547,12 +4547,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4566,17 +4566,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4590,17 +4590,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4619,17 +4619,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4649,17 +4649,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4673,17 +4673,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4699,17 +4699,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4729,17 +4729,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4771,17 +4771,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4803,17 +4803,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4830,17 +4830,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4855,17 +4855,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4885,17 +4885,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4917,17 +4917,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4951,12 +4951,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4980,12 +4980,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -4999,17 +4999,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5033,17 +5033,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5064,17 +5064,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5089,17 +5089,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5115,17 +5115,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5141,17 +5141,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5172,17 +5172,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5214,17 +5214,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5246,17 +5246,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5273,17 +5273,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -5298,17 +5298,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },

--- a/src/test/assets/studentenwerk/mensa-garching/reference/week_37.json
+++ b/src/test/assets/studentenwerk/mensa-garching/reference/week_37.json
@@ -10,17 +10,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -42,17 +42,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -80,12 +80,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -111,12 +111,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -133,17 +133,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -162,17 +162,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -197,17 +197,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -224,17 +224,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -249,17 +249,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -275,17 +275,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -304,17 +304,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -330,17 +330,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -372,17 +372,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -404,17 +404,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -437,17 +437,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -463,17 +463,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -502,17 +502,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -527,17 +527,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -557,17 +557,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -589,17 +589,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -623,17 +623,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -659,12 +659,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -688,12 +688,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -713,17 +713,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -741,17 +741,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -779,17 +779,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -808,17 +808,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -833,17 +833,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -861,17 +861,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -886,17 +886,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -928,17 +928,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -960,17 +960,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -993,17 +993,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1019,17 +1019,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1044,17 +1044,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1074,17 +1074,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1104,17 +1104,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1148,12 +1148,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1176,12 +1176,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1200,17 +1200,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1233,17 +1233,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1267,17 +1267,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1297,17 +1297,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1323,17 +1323,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1347,17 +1347,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1372,17 +1372,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1398,17 +1398,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1440,17 +1440,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1474,17 +1474,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1500,17 +1500,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1530,17 +1530,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1560,17 +1560,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1585,17 +1585,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1615,17 +1615,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1648,17 +1648,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1682,17 +1682,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1721,17 +1721,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1758,12 +1758,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1786,12 +1786,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1810,17 +1810,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1836,17 +1836,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1869,17 +1869,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1906,17 +1906,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1938,17 +1938,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1976,17 +1976,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2003,17 +2003,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2029,17 +2029,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2054,17 +2054,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2083,17 +2083,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2111,17 +2111,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2137,17 +2137,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2165,17 +2165,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2207,17 +2207,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2239,17 +2239,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2269,17 +2269,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2308,17 +2308,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2333,17 +2333,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2363,17 +2363,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2395,17 +2395,17 @@
           "prices": {
             "students": {
               "base_price": 1.5,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.5,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.5,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2426,17 +2426,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2464,12 +2464,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2492,12 +2492,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2525,12 +2525,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2548,17 +2548,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2574,17 +2574,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2609,17 +2609,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2639,17 +2639,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2664,17 +2664,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2689,17 +2689,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2719,17 +2719,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2744,17 +2744,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2786,17 +2786,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2818,17 +2818,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2849,17 +2849,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2879,17 +2879,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2904,17 +2904,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },

--- a/src/test/assets/studentenwerk/mensa-garching/reference/week_38.json
+++ b/src/test/assets/studentenwerk/mensa-garching/reference/week_38.json
@@ -10,17 +10,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -43,17 +43,17 @@
           "prices": {
             "students": {
               "base_price": 0.5,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0.5,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0.5,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -71,17 +71,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -106,12 +106,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -131,12 +131,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -153,17 +153,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -184,17 +184,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -211,17 +211,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -237,17 +237,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -265,17 +265,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -291,17 +291,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -316,17 +316,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -340,17 +340,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -382,17 +382,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -414,17 +414,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -441,17 +441,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -473,17 +473,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -498,17 +498,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -530,17 +530,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -560,17 +560,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -591,17 +591,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -631,12 +631,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -659,12 +659,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -678,17 +678,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -711,17 +711,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -740,17 +740,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -767,17 +767,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -792,17 +792,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -818,17 +818,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -843,17 +843,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -869,17 +869,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -911,17 +911,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -943,17 +943,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -970,17 +970,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -995,17 +995,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1025,17 +1025,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1056,17 +1056,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1087,12 +1087,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1114,12 +1114,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1133,17 +1133,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1162,17 +1162,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1195,17 +1195,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1221,17 +1221,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1249,17 +1249,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1275,17 +1275,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1304,17 +1304,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1329,17 +1329,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1371,17 +1371,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1403,17 +1403,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1429,17 +1429,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1454,17 +1454,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1484,17 +1484,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1515,17 +1515,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1550,17 +1550,17 @@
           "prices": {
             "students": {
               "base_price": 0.5,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0.5,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0.5,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1583,12 +1583,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1613,12 +1613,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1632,17 +1632,17 @@
           "prices": {
             "students": {
               "base_price": 1.0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1656,17 +1656,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1685,17 +1685,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1715,17 +1715,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1739,17 +1739,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1765,17 +1765,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1795,17 +1795,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1837,17 +1837,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1869,17 +1869,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1896,17 +1896,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1921,17 +1921,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1951,17 +1951,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -1983,17 +1983,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2017,12 +2017,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2046,12 +2046,12 @@
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.55,
+              "price_per_unit": 0.65,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 0.66,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2065,17 +2065,17 @@
           "prices": {
             "students": {
               "base_price": 1.5,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 1.5,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 1.5,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2099,17 +2099,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2130,17 +2130,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2155,17 +2155,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2181,17 +2181,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2207,17 +2207,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2238,17 +2238,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2280,17 +2280,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2312,17 +2312,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2339,17 +2339,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },
@@ -2364,17 +2364,17 @@
           "prices": {
             "students": {
               "base_price": 0,
-              "price_per_unit": 0.75,
+              "price_per_unit": 0.80,
               "unit": "100g"
             },
             "staff": {
               "base_price": 0,
-              "price_per_unit": 0.9,
+              "price_per_unit": 1.00,
               "unit": "100g"
             },
             "guests": {
               "base_price": 0,
-              "price_per_unit": 1.05,
+              "price_per_unit": 1.35,
               "unit": "100g"
             }
           },

--- a/src/test/assets/studentenwerk/stubistro-grosshadern/reference/combined.json
+++ b/src/test/assets/studentenwerk/stubistro-grosshadern/reference/combined.json
@@ -14,17 +14,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -51,12 +51,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -77,17 +77,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -102,17 +102,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -127,17 +127,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -151,17 +151,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -176,17 +176,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -202,17 +202,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -244,17 +244,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -276,17 +276,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -307,17 +307,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -339,17 +339,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -375,12 +375,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -399,17 +399,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -435,17 +435,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -463,17 +463,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -489,17 +489,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -517,17 +517,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -545,17 +545,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -571,17 +571,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -597,17 +597,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -625,17 +625,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -667,17 +667,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -699,17 +699,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -731,17 +731,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -761,17 +761,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -795,12 +795,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -823,12 +823,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -843,17 +843,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -869,17 +869,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -894,17 +894,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -920,17 +920,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -946,17 +946,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -988,17 +988,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1020,17 +1020,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1050,17 +1050,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1087,12 +1087,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1115,12 +1115,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1135,17 +1135,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1167,17 +1167,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1200,17 +1200,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1226,17 +1226,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1256,17 +1256,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1281,17 +1281,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1309,17 +1309,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1335,17 +1335,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1361,17 +1361,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1390,17 +1390,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1432,17 +1432,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1464,17 +1464,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1493,17 +1493,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1524,17 +1524,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1565,12 +1565,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1587,17 +1587,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1617,17 +1617,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1647,17 +1647,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1671,17 +1671,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1696,17 +1696,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1721,17 +1721,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1746,17 +1746,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1772,17 +1772,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1802,17 +1802,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1844,17 +1844,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1876,17 +1876,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1914,17 +1914,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1947,12 +1947,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1967,17 +1967,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -1998,17 +1998,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2023,17 +2023,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2048,17 +2048,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2074,17 +2074,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2099,17 +2099,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2141,17 +2141,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2173,17 +2173,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2202,17 +2202,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2242,12 +2242,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2265,17 +2265,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2298,17 +2298,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2323,17 +2323,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2348,17 +2348,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2374,17 +2374,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2400,17 +2400,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2442,17 +2442,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2474,17 +2474,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2503,17 +2503,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2539,12 +2539,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2560,17 +2560,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2592,17 +2592,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2620,17 +2620,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2648,17 +2648,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2674,17 +2674,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2703,17 +2703,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2745,17 +2745,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2777,17 +2777,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2806,17 +2806,17 @@
               "prices": {
                 "students": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2839,12 +2839,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2863,17 +2863,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2892,17 +2892,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2917,17 +2917,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2941,17 +2941,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2967,17 +2967,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -2992,17 +2992,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3034,17 +3034,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3066,17 +3066,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3100,12 +3100,12 @@
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.55,
+                  "price_per_unit": 0.65,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 0.66,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3124,17 +3124,17 @@
               "prices": {
                 "students": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 1.5,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 1.5,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3158,17 +3158,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3189,17 +3189,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3219,17 +3219,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3244,17 +3244,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3270,17 +3270,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3300,17 +3300,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3342,17 +3342,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },
@@ -3374,17 +3374,17 @@
               "prices": {
                 "students": {
                   "base_price": 0,
-                  "price_per_unit": 0.75,
+                  "price_per_unit": 0.80,
                   "unit": "100g"
                 },
                 "staff": {
                   "base_price": 0,
-                  "price_per_unit": 0.9,
+                  "price_per_unit": 1.00,
                   "unit": "100g"
                 },
                 "guests": {
                   "base_price": 0,
-                  "price_per_unit": 1.05,
+                  "price_per_unit": 1.35,
                   "unit": "100g"
                 }
               },

--- a/src/test/test_menu_parser.py
+++ b/src/test/test_menu_parser.py
@@ -58,7 +58,7 @@ class StudentenwerkMenuParserTest(unittest.TestCase):
         start_date += datetime.timedelta(days=1)
 
     def test_studentenwerk(self) -> None:
-        canteens = [ Canteen.MENSA_ARCISSTR, Canteen.STUBISTRO_GROSSHADERN,Canteen.MENSA_GARCHING]
+        canteens = [Canteen.MENSA_ARCISSTR, Canteen.STUBISTRO_GROSSHADERN, Canteen.MENSA_GARCHING]
         for canteen in canteens:
             self.__test_studentenwerk_canteen(canteen)
 

--- a/src/test/test_menu_parser.py
+++ b/src/test/test_menu_parser.py
@@ -58,7 +58,7 @@ class StudentenwerkMenuParserTest(unittest.TestCase):
         start_date += datetime.timedelta(days=1)
 
     def test_studentenwerk(self) -> None:
-        canteens = [Canteen.MENSA_GARCHING, Canteen.MENSA_ARCISSTR, Canteen.STUBISTRO_GROSSHADERN]
+        canteens = [ Canteen.MENSA_ARCISSTR, Canteen.STUBISTRO_GROSSHADERN,Canteen.MENSA_GARCHING]
         for canteen in canteens:
             self.__test_studentenwerk_canteen(canteen)
 


### PR DESCRIPTION
This PR repairs the tests that have failed to pass since the [PR](https://github.com/TUM-Dev/eat-api/pull/155). For this, all prices have been adjusted to the new values.