### PR TITLE
Add Stucafe Connollystraße

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -283,6 +283,17 @@ class Canteen(ApiRepresentable, Enum):
         None,
         OpenHours(("08:00", "16:00"), ("08:00", "16:00"), ("08:00", "16:00"), ("08:00", "16:00"), ("08:00", "15:00")),
     )
+    STUCAFE_CONNOLLYSTR = (
+        "StuCafé Connollystraße",
+        Location(
+            "Connollystraße 32, München",
+            48.179222,
+            11.546377,
+        ),
+        425,
+        None,
+        OpenHours(("09:00", "15:00"), ("09:00", "15:00"), ("09:00", "15:00"), ("09:00", "15:00"), ("09:00", "14:00")),
+    )
     STUCAFE_GARCHING = (
         "StuCafé in der Mensa Garching",
         Location(

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -77,6 +77,7 @@ class StudentenwerkMenuParser(MenuParser):
         Canteen.STUCAFE_ADALBERTSTR,
         Canteen.STUCAFE_AKADEMIE_WEIHENSTEPHAN,
         Canteen.STUCAFE_BOLTZMANNSTR,
+        Canteen.STUCAFE_CONNOLLYSTR,
         Canteen.STUCAFE_GARCHING,
         Canteen.STUCAFE_KARLSTR,
         Canteen.STUCAFE_PASING,


### PR DESCRIPTION
# Stucafe Connollystraße
Added the [stucafe Connollystraße](https://www.studentenwerk-muenchen.de/stucafe-olympiapark/) to the list of all cafeterias.
Since it uses the same template for mealplans, no parser had to be adapted.
The mealplan can be found [here](https://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_425_-de.html).
The coordinates are defined with the help of [maps](https://www.google.com/maps/@48.1793532,11.5465894,19z).