### PR TITLE
New stuwerk URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/TUM-Dev/eat-api/workflows/CI%2FCD/badge.svg)](https://github.com/TUM-Dev/eat-api/actions)
 
 
-Simple static API for the canteens of the [Studentenwerk München](http://www.studentenwerk-muenchen.de) as well as some other canteens. By now, the following canteens are supported:
+Simple static API for the canteens of the [Studierendenwerk München Oberbayern](http://www.studierendenwerk-muenchen-oberbayern.de) as well as some other canteens. By now, the following canteens are supported:
 
 | Name                           | API-key                        | Address                                                                                                                     |
 | :----------------------------- | :----------------------------- |:----------------------------------------------------------------------------------------------------------------------------|

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -85,7 +85,7 @@ class StudentenwerkMenuParser(MenuParser):
         Canteen.STUCAFE_PASING,
     }
 
-    # Prices taken from: https://www.studentenwerk-muenchen.de/mensa/mensa-preise/
+    # Prices taken from: https://www.studierendenwerk-muenchen-oberbayern.de/mensa/mensa-preise/
 
     # Base price for sausage, meat and fish. The price is the same for all meals except pizza
     # only the first values is used in the triplets which do not contain pizza.
@@ -241,9 +241,9 @@ class StudentenwerkMenuParser(MenuParser):
                 base_price_type = StudentenwerkMenuParser.SelfServiceBasePriceType.PIZZA_VEGIE
         return StudentenwerkMenuParser.__get_self_service_prices(base_price_type, price_per_unit_type)
 
-    base_url: str = "http://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_{url_id}_-de.html"
+    base_url: str = "http://www.studierendenwerk-muenchen-oberbayern.de/mensa/speiseplan/speiseplan_{url_id}_-de.html"
     base_url_with_date: str = (
-        "http://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_{date}_{url_id}_-de.html"
+        "http://www.studierendenwerk-muenchen-oberbayern.de/mensa/speiseplan/speiseplan_{date}_{url_id}_-de.html"
     )
 
     def parse(self, canteen: Canteen) -> Optional[Dict[datetime.date, Menu]]:


### PR DESCRIPTION
The stuwerk changed their domain to [studierendenwerk-muenchen-oberbayern.de](https://www.studierendenwerk-muenchen-oberbayern.de/). Currently there is a redirect in place, this PR adds the updated URL in case the redirect stops working some time. 