### PR TITLE
update opening hours for Mensa Garching

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -171,7 +171,7 @@ class Canteen(ApiRepresentable, Enum):
         Location("Boltzmannstraße 19, Garching", 48.268132, 11.672263),
         422,
         "https://mensa.liste.party/api/",
-        OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
+        OpenHours(("11:00", "14:30"), ("11:00", "14:30"), ("11:00", "14:30"), ("11:00", "14:30"), ("11:00", "14:00")),
     )
     MENSA_LEOPOLDSTR = (
         "Mensa Leopoldstraße",


### PR DESCRIPTION
The opening hours for the Mensa Garching have changed a while ago.

This PR updates the opening hours on days Monday to Thursday from 11:00-14:00 to 11:00-14:**30** according to the [website of the "Studierendenwerk"](https://www.studierendenwerk-muenchen-oberbayern.de/mensa/standorte-und-oeffnungszeiten/garching/).