### PR TITLE
Add capacity api for some hochschul-canteens

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -185,7 +185,7 @@ class Canteen(ApiRepresentable, Enum):
         "Mensa Lothstraße",
         Location("Lothstraße 13d, München", 48.153989, 11.552424),
         431,
-        None,
+        "https://beta.api.betterhm.app/v1/capacity/MENSA_LOTHSTR",
         OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
     )
     MENSA_MARTINSRIED = (
@@ -199,7 +199,7 @@ class Canteen(ApiRepresentable, Enum):
         "Mensa Pasing",
         Location("Am Stadtpark 20, München", 48.141568, 11.451119),
         432,
-        None,
+        "https://beta.api.betterhm.app/v1/capacity/MENSA_PASING",
         OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
     )
     MENSA_WEIHENSTEPHAN = (
@@ -336,7 +336,7 @@ class Canteen(ApiRepresentable, Enum):
         "StuCafé Pasing",
         Location("Am Stadtpark 20, München", 48.141568, 11.451119),
         534,
-        None,
+        "https://beta.api.betterhm.app/v1/capacity/STUCAFE_PASING",
         OpenHours(("07:45", "16:15"), ("07:45", "16:15"), ("07:45", "16:00"), ("07:45", "16:00"), ("07:45", "14:30")),
     )
     IPP_BISTRO = (

--- a/src/entities.py
+++ b/src/entities.py
@@ -185,7 +185,7 @@ class Canteen(ApiRepresentable, Enum):
         "Mensa Lothstraße",
         Location("Lothstraße 13d, München", 48.153989, 11.552424),
         431,
-        "https://beta.api.betterhm.app/v1/capacity/MENSA_LOTHSTR",
+        "https://api.betterhm.app/v1/capacity/MENSA_LOTHSTR",
         OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
     )
     MENSA_MARTINSRIED = (
@@ -199,7 +199,7 @@ class Canteen(ApiRepresentable, Enum):
         "Mensa Pasing",
         Location("Am Stadtpark 20, München", 48.141568, 11.451119),
         432,
-        "https://beta.api.betterhm.app/v1/capacity/MENSA_PASING",
+        "https://api.betterhm.app/v1/capacity/MENSA_PASING",
         OpenHours(("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00"), ("11:00", "14:00")),
     )
     MENSA_WEIHENSTEPHAN = (
@@ -336,7 +336,7 @@ class Canteen(ApiRepresentable, Enum):
         "StuCafé Pasing",
         Location("Am Stadtpark 20, München", 48.141568, 11.451119),
         534,
-        "https://beta.api.betterhm.app/v1/capacity/STUCAFE_PASING",
+        "https://api.betterhm.app/v1/capacity/STUCAFE_PASING",
         OpenHours(("07:45", "16:15"), ("07:45", "16:15"), ("07:45", "16:00"), ("07:45", "16:00"), ("07:45", "14:30")),
     )
     IPP_BISTRO = (


### PR DESCRIPTION
We made an api for some canteens of the "Hochschule München". The API scheme is compatible with the currently present one on MENSA_GARCHING