### PR TITLE
Update Python.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,41 @@
-[tool.poetry]
+[project]
 name = "eat-api"
 version = "0.1.0"
 description = "Simple API for some (student) food places in Munich."
-authors = ["TUM-Dev"]
+authors = [{ name = "TUM-Dev" }]
 license = "MIT"
+readme = "README.md"
+requires-python = ">= 3.9"
+dependencies = [
+    "lxml~=5.3",
+    "pyopenmensa~=0.95",
+    "requests~=2.32",
+    "deepl>=1.2.1",
+]
+
+[dependency-groups]
+dev = [
+    "mypy~=1.14",
+    "pre-commit~=4.1",
+    "pylint~=3.3",
+    "pytest~=8.3",
+    "types-requests~=2.32",
+]
+
+[project.urls]
+homepage = "https://eat-api.tum.sexy/"
+repository = "https://github.com/TUM-Dev/eat-api"
+issues = "https://github.com/TUM-Dev/eat-api/issues"
+documentation = "https://tum-dev.github.io/eat-api/docs/"
+
+[tool.poetry]
 package-mode = false
 
+# needed for poetry's locking
 [tool.poetry.dependencies]
-python = "^3.9"
-lxml = "~5.3"
-pyopenmensa = "~0.95"
-requests = "~2.32"
-deepl = "^1.2.1"
-
-[tool.poetry.dev-dependencies]
-mypy = "~1.14"
-pre-commit = "~4.1"
-pylint = "~3.3"
-pytest = "~8.3"
-types-requests = "~2.32"
+python = ">= 3.9,<4"
 
 [tool.mypy]
-python_version = 3.9
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 no_implicit_optional = true
@@ -66,7 +80,3 @@ line-length = 120
 [tool.isort]
 profile = "black"
 line_length = 120
-
-[build-system]
-requires = ["poetry>=1.0.0"]
-build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,28 +50,29 @@ pretty = true
 jobs = 1
 
 [tool.pylint.message_control]
-disable = ["missing-function-docstring", # too much work
-        "missing-module-docstring", # too much work
-        "missing-class-docstring", # too much work
-        "line-too-long", # we have another hook for this
-        "wrong-import-position", # we have another hook for this
-        "no-member", # mypy does this job with less false positives
-        "no-else-return", # depending on dev this is an antipattern.. not touching this debate
-        "no-else-continue", # depending on dev this is an antipattern.. not touching this debate
-        "no-else-break", # depending on dev this is an antipattern.. not touching this debate
-        "invalid-name", # possible api-change.. DONT
-        "fixme", # prevents users from committing things with a TODO in comments. Having more frequent commits is desirable
-        "pointless-string-statement", # those care "comments"
-        "too-many-locals", # TODO code quality
-        "too-many-statements", # TODO code quality
-        "too-many-branches", # TODO code quality
-        "too-few-public-methods", #TODO code quality
-        "too-many-arguments",
-        "unsubscriptable-object",
-        "consider-using-dict-items",
-        "import-error", # produces weird PYTHONPATH issues. WONTFIX until pylint/pre-commit allows setting environment options.
-        # to run this locally remove this line temporarily and call
-        # `PYTHONPATH=./src pre-commit run -a` and `PYTHONPATH=./scripts pre-commit run -a`
+disable = [
+    "missing-function-docstring", # too much work
+    "missing-module-docstring", # too much work
+    "missing-class-docstring", # too much work
+    "line-too-long", # we have another hook for this
+    "wrong-import-position", # we have another hook for this
+    "no-member", # mypy does this job with less false positives
+    "no-else-return", # depending on dev this is an antipattern.. not touching this debate
+    "no-else-continue", # depending on dev this is an antipattern.. not touching this debate
+    "no-else-break", # depending on dev this is an antipattern.. not touching this debate
+    "invalid-name", # possible api-change.. DONT
+    "fixme", # prevents users from committing things with a TODO in comments. Having more frequent commits is desirable
+    "pointless-string-statement", # those care "comments"
+    "too-many-locals", # TODO code quality
+    "too-many-statements", # TODO code quality
+    "too-many-branches", # TODO code quality
+    "too-few-public-methods", #TODO code quality
+    "too-many-arguments",
+    "unsubscriptable-object",
+    "consider-using-dict-items",
+    "import-error", # produces weird PYTHONPATH issues. WONTFIX until pylint/pre-commit allows setting environment options.
+    # to run this locally remove this line temporarily and call
+    # `PYTHONPATH=./src pre-commit run -a` and `PYTHONPATH=./scripts pre-commit run -a`
 ]
 
 [tool.black]

--- a/src/entities.py
+++ b/src/entities.py
@@ -564,12 +564,12 @@ class Dish:
         return {
             "name": self.name,
             "prices": self.prices.to_json_obj(),
-            "labels": sorted(map(lambda l: l.name, self.labels)),
+            "labels": sorted(map(lambda label: label.name, self.labels)),  # type: ignore
             "dish_type": self.dish_type,
         }
 
     def __hash__(self) -> int:
-        # http://stackoverflow.com/questions/4005318/how-to-implement-a-good-hash-function-in-python
+        # https://stackoverflow.com/questions/4005318/how-to-implement-a-good-hash-function-in-python
         return (hash(self.name) << 1) ^ hash(self.prices) ^ hash(frozenset(self.labels)) ^ hash(self.dish_type)
 
 


### PR DESCRIPTION
this changes dependencies from poetry specific format into the general python one
Poetry can only use this format since its version 2.

see https://packaging.python.org/en/latest/guides/writing-pyproject-toml, [dev deps](https://packaging.python.org/en/latest/specifications/dependency-groups/), [Poetry setup](https://python-poetry.org/docs/basic-usage/#project-setup)