### PR TITLE
More reliable and simpler canteen list handling

### DIFF
--- a/scripts/parse.sh
+++ b/scripts/parse.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-CANTEEN_LIST=$(python3 src/main.py --canteens | python3 scripts/parse_canteen_list.py)
+set -e
+
+CANTEEN_LIST=$(python3 src/main.py --canteen-ids)
 OUT_DIR="${OUT_DIR:-dist}"
 LANGUAGE="${LANGUAGE_EAT_API:-DE}"
 

--- a/scripts/parse_canteen_list.py
+++ b/scripts/parse_canteen_list.py
@@ -1,9 +1,0 @@
-# script to show canteen_ids from json output line by line
-
-import json
-import sys
-
-if __name__ == "__main__":
-    canteens = json.load(sys.stdin)
-    for canteen in canteens:
-        print(canteen["canteen_id"])

--- a/src/cli.py
+++ b/src/cli.py
@@ -46,6 +46,11 @@ def parse_cli_args():
         action="store_true",
         help="prints all available canteens formated as JSON",
     )
+    group.add_argument(
+        "--canteen-ids",
+        action="store_true",
+        help="prints all available canteen IDs to stdout with a new line after each canteen",
+    )
     parser.add_argument(
         "--language",
         help="The language to translate the dish titles to, "

--- a/src/main.py
+++ b/src/main.py
@@ -89,6 +89,10 @@ def main():
     # print canteens
     if args.canteens:
         sys.exit(enum_json_creator.enum_to_api_representation_dict(list(Canteen)))
+    if args.canteen_ids:
+        for c in list(Canteen):
+            print(c.canteen_id)
+        sys.exit()
 
     canteen = Canteen.get_canteen_by_str(args.canteen)
     # get required parser


### PR DESCRIPTION
Fixes #282 by directly providing a `--canteen-ids` parameter that prints canteen id and exits.
That way we do not have to rely on the additional parser script that can handle only stdin input.

Fixes the following CI crash:
```
Traceback (most recent call last):
  File "/home/runner/work/eat-api/eat-api/scripts/parse_canteen_list.py", line 7, in <module>
    canteens = json.load(sys.stdin)
               ^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

https://github.com/TUM-Dev/eat-api/actions/runs/13218416986/job/36900479138