### PR TITLE
chore: add permissions block to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ master ]
+permissions:
+  contents: read
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
-
   pytest:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
CodeQL complains about this not being here and it somewhat makes sense to add it.

This PR also remvoes the pre-commit from CI as we are now running this a different way